### PR TITLE
[BE] 회원탈퇴 API 구현

### DIFF
--- a/BE/src/main/java/com/twopilogue/intervyou/config/auth/PrincipalDetailsService.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/config/auth/PrincipalDetailsService.java
@@ -16,7 +16,7 @@ public class PrincipalDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String naverIdToken) throws UsernameNotFoundException {
-        User userEntity = userRepository.findByNaverIdToken(naverIdToken);
+        User userEntity = userRepository.findByNaverIdTokenAndWithdrawalTimeIsNull(naverIdToken);
         return new PrincipalDetails(userEntity);
     }
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/config/jwt/JwtAuthorizationFilter.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/config/jwt/JwtAuthorizationFilter.java
@@ -43,7 +43,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
         }
         String naverIdToken = jwtProvider.validateToken(request);
         if (naverIdToken != null) {
-            User userEntity = userRepository.findByNaverIdToken(naverIdToken);
+            User userEntity = userRepository.findByNaverIdTokenAndWithdrawalTimeIsNull(naverIdToken);
             PrincipalDetails principalDetails = new PrincipalDetails(userEntity);
             Authentication authentication = new UsernamePasswordAuthenticationToken(principalDetails, null, principalDetails.getAuthorities());
             SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/BE/src/main/java/com/twopilogue/intervyou/user/constant/UserConstant.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/user/constant/UserConstant.java
@@ -6,4 +6,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserConstant {
     public static final String LOGIN_SUCCESS_MESSAGE = "로그인을 완료했습니다.";
+    public static final String WITHDRAWAL_SUCCESS_MESSAGE = "회원 탈퇴를 완료했습니다.";
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/user/controller/UserController.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/user/controller/UserController.java
@@ -1,13 +1,16 @@
 package com.twopilogue.intervyou.user.controller;
 
 import com.twopilogue.intervyou.common.dto.BaseResponse;
+import com.twopilogue.intervyou.config.auth.PrincipalDetails;
 import com.twopilogue.intervyou.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import static com.twopilogue.intervyou.user.constant.UserConstant.LOGIN_SUCCESS_MESSAGE;
+import static com.twopilogue.intervyou.user.constant.UserConstant.WITHDRAWAL_SUCCESS_MESSAGE;
 
 @CrossOrigin("*")
 @RestController
@@ -20,6 +23,12 @@ public class UserController {
     @GetMapping("/login")
     public ResponseEntity<BaseResponse> login(@RequestParam("code") String code) {
         return new ResponseEntity<>(BaseResponse.from(LOGIN_SUCCESS_MESSAGE, userService.login(code)), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/withdrawal")
+    public ResponseEntity<BaseResponse> withdrawal(@AuthenticationPrincipal final PrincipalDetails principalDetails) {
+        userService.withdrawal(principalDetails.getUsername());
+        return new ResponseEntity<>(BaseResponse.from(WITHDRAWAL_SUCCESS_MESSAGE), HttpStatus.OK);
     }
 
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/user/entity/User.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/user/entity/User.java
@@ -23,4 +23,8 @@ public class User {
 
     @Column(name = "withdrawal_time")
     private LocalDateTime withdrawalTime;
+
+    public void withdrawal() {
+        this.withdrawalTime = LocalDateTime.now();
+    }
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/user/exception/UserErrorResult.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/user/exception/UserErrorResult.java
@@ -12,6 +12,7 @@ public enum UserErrorResult implements BaseErrorResult {
     UNREGISTERED_USER(HttpStatus.FORBIDDEN, "등록되지 않은 사용자입니다."),
     EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
     FAIL_VALIDATE_TOKEN(HttpStatus.FORBIDDEN, "토큰 인증에 실패했습니다."),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/BE/src/main/java/com/twopilogue/intervyou/user/repository/UserRepository.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/user/repository/UserRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    User findByNaverIdToken(final String naverIdToken);
+    User findByNaverIdTokenAndWithdrawalTimeIsNull(final String naverIdToken);
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/user/service/UserService.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/user/service/UserService.java
@@ -5,11 +5,14 @@ import com.twopilogue.intervyou.user.dto.response.LoginResponse;
 import com.twopilogue.intervyou.user.dto.response.naver.NaverIdTokenResponse;
 import com.twopilogue.intervyou.user.dto.response.naver.NaverTokenResponse;
 import com.twopilogue.intervyou.user.entity.User;
+import com.twopilogue.intervyou.user.exception.UserErrorResult;
+import com.twopilogue.intervyou.user.exception.UserException;
 import com.twopilogue.intervyou.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
@@ -25,10 +28,11 @@ public class UserService {
     @Value("${naver.key.cliend-secret}")
     private String naverClientSecret;
 
+    @Transactional
     public LoginResponse login(final String code) {
         final String naverAccessToken = getNaverAccessToken(code);
         final String naverIdToken = getNaverIdToken(naverAccessToken);
-        User user = userRepository.findByNaverIdToken(naverIdToken);
+        User user = userRepository.findByNaverIdTokenAndWithdrawalTimeIsNull(naverIdToken);
 
         if (user == null) {
             user = userRepository.save(User.builder()

--- a/BE/src/main/java/com/twopilogue/intervyou/user/service/UserService.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/user/service/UserService.java
@@ -43,6 +43,15 @@ public class UserService {
         return LoginResponse.builder().id(user.getUserId()).token(jwtProvider.createToken(user)).build();
     }
 
+    @Transactional
+    public void withdrawal(final String naverIdToken) {
+        final User user = userRepository.findByNaverIdTokenAndWithdrawalTimeIsNull(naverIdToken);
+        if (user == null) {
+            throw new UserException(UserErrorResult.NOT_FOUND_USER);
+        }
+        user.withdrawal();
+    }
+
     private String getNaverAccessToken(final String code) {
         final NaverTokenResponse naverTokenResponse = WebClient.create("https://nid.naver.com").get()
                 .uri(uriBuilder -> uriBuilder.path("/oauth2.0/token")


### PR DESCRIPTION
close #12 

### 1. 로그인 로직 수정
- 탈퇴하지 않은 사용자만 로그인이 가능하도록 수정했습니다.

### 2. 회원 탈퇴 API 구현
- 회원 탈퇴 로직을 구현했습니다.
- 게시글과 면접 데이터 처리는 추후 개발 예정입니다.