### PR TITLE
[BE] 댓글 등록 API 구현

### DIFF
--- a/BE/src/main/java/com/twopilogue/intervyou/community/constant/CommunityConstant.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/constant/CommunityConstant.java
@@ -7,4 +7,5 @@ import lombok.NoArgsConstructor;
 public class CommunityConstant {
     public static final String WRITE_POST_SUCCESS_MESSAGE = "게시글 작성이 완료되었습니다.";
     public static final String MODIFY_POST_SUCCESS_MESSAGE = "게시글 수정이 완료되었습니다.";
+    public static final String WRITE_COMMENT_SUCCESS_MESSAGE = "댓글 등록이 완료되었습니다.";
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/community/controller/CommunityController.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/controller/CommunityController.java
@@ -2,6 +2,7 @@ package com.twopilogue.intervyou.community.controller;
 
 import com.twopilogue.intervyou.common.BaseResponse;
 import com.twopilogue.intervyou.community.dto.request.ModifyPostRequest;
+import com.twopilogue.intervyou.community.dto.request.WriteCommentRequest;
 import com.twopilogue.intervyou.community.dto.request.WritePostRequest;
 import com.twopilogue.intervyou.community.service.CommunityService;
 import com.twopilogue.intervyou.config.auth.PrincipalDetails;
@@ -13,8 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
-import static com.twopilogue.intervyou.community.constant.CommunityConstant.MODIFY_POST_SUCCESS_MESSAGE;
-import static com.twopilogue.intervyou.community.constant.CommunityConstant.WRITE_POST_SUCCESS_MESSAGE;
+import static com.twopilogue.intervyou.community.constant.CommunityConstant.*;
 
 @CrossOrigin("*")
 @RestController
@@ -36,5 +36,12 @@ public class CommunityController {
                                                    @RequestBody @Valid final ModifyPostRequest modifyPostRequest) {
         communityService.modifyPost(principalDetails.getUser(), communityId, modifyPostRequest);
         return new ResponseEntity<>(BaseResponse.from(MODIFY_POST_SUCCESS_MESSAGE), HttpStatus.OK);
+    }
+
+    @PostMapping("/{communityId}/comments")
+    public ResponseEntity<BaseResponse> writeComment(@AuthenticationPrincipal final PrincipalDetails principalDetails,
+                                                     @PathVariable final long communityId,
+                                                     @RequestBody @Valid final WriteCommentRequest writeCommentRequest) {
+        return new ResponseEntity<>(BaseResponse.from(WRITE_COMMENT_SUCCESS_MESSAGE, communityService.writeComment(principalDetails.getUser(), communityId, writeCommentRequest)), HttpStatus.OK);
     }
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/community/dto/request/WriteCommentRequest.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/dto/request/WriteCommentRequest.java
@@ -1,0 +1,17 @@
+package com.twopilogue.intervyou.community.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Builder
+public class WriteCommentRequest {
+
+    private Long parentCommentId;
+
+    @NotBlank
+    private String commentContent;
+
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/community/dto/response/WriteCommentResponse.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/dto/response/WriteCommentResponse.java
@@ -1,0 +1,17 @@
+package com.twopilogue.intervyou.community.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class WriteCommentResponse {
+    private long commentId;
+    private long communityId;
+    private Long parentCommentId;
+    private String commentContent;
+    private String nickname;
+    private String createTime;
+    private int depth;
+    private int group;
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/community/entity/Comment.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/entity/Comment.java
@@ -1,0 +1,48 @@
+package com.twopilogue.intervyou.community.entity;
+
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "comment")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 15)
+    private String nickname;
+
+    @Column(name = "community_id", nullable = false)
+    private Long communityId;
+
+    @Column(name = "parent_community_id")
+    private Long parentCommentId;
+
+    @Column(name = "comment_content", nullable = false, length = 1000)
+    private String commentContent;
+
+    private int depth;
+
+    private int commentGroup;
+
+    @CreationTimestamp
+    @Column(name = "create_time")
+    private LocalDateTime createTime;
+
+    @UpdateTimestamp
+    @Column(name = "update_time")
+    private LocalDateTime updateTime;
+
+    @Column(name = "delete_time")
+    private LocalDateTime deleteTime;
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/community/exception/CommunityErrorResult.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/exception/CommunityErrorResult.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum CommunityErrorResult implements BaseErrorResult {
 
     INVALID_POST(HttpStatus.BAD_REQUEST, "유효하지 않은 게시글입니다."),
+    INVALID_COMMENT(HttpStatus.BAD_REQUEST, "유효하지 않은 댓글입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommentRepository.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommentRepository.java
@@ -1,0 +1,11 @@
+package com.twopilogue.intervyou.community.repositiry;
+
+import com.twopilogue.intervyou.community.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    Comment findByIdAndCommunityIdAndDeleteTimeIsNull(final long id, final long communityId);
+    int countByCommunityIdAndDepth(final long communityId, final int depth);
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommunityRepository.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommunityRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommunityRepository extends JpaRepository<Community, Long> {
-    Community findByIdAndNickname(final long id, final String nickname);
+    Community findByIdAndNicknameAndDeleteTimeIsNull(final long id, final String nickname);
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommunityRepository.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommunityRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CommunityRepository extends JpaRepository<Community, Long> {
     Community findByIdAndNicknameAndDeleteTimeIsNull(final long id, final String nickname);
+    Community findByIdAndDeleteTimeIsNull(final long id);
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/community/service/CommunityService.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/service/CommunityService.java
@@ -1,24 +1,32 @@
 package com.twopilogue.intervyou.community.service;
 
 import com.twopilogue.intervyou.community.dto.request.ModifyPostRequest;
+import com.twopilogue.intervyou.community.dto.request.WriteCommentRequest;
 import com.twopilogue.intervyou.community.dto.request.WritePostRequest;
+import com.twopilogue.intervyou.community.dto.response.WriteCommentResponse;
 import com.twopilogue.intervyou.community.dto.response.WritePostResponse;
+import com.twopilogue.intervyou.community.entity.Comment;
 import com.twopilogue.intervyou.community.entity.Community;
 import com.twopilogue.intervyou.community.exception.CommunityErrorResult;
 import com.twopilogue.intervyou.community.exception.CommunityException;
+import com.twopilogue.intervyou.community.repositiry.CommentRepository;
 import com.twopilogue.intervyou.community.repositiry.CommunityRepository;
 import com.twopilogue.intervyou.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CommunityService {
 
     private final CommunityRepository communityRepository;
+    private final CommentRepository commentRepository;
 
-    @Transactional
     public WritePostResponse writePost(final User user, final WritePostRequest writePostRequest) {
 
         final Community community = communityRepository.save(Community.builder()
@@ -33,13 +41,57 @@ public class CommunityService {
 
     }
 
-    @Transactional
     public void modifyPost(final User user, final long communityId, final ModifyPostRequest modifyPostRequest) {
         final Community community = communityRepository.findByIdAndNicknameAndDeleteTimeIsNull(communityId, user.getNickname());
         if (community == null) {
             throw new CommunityException(CommunityErrorResult.INVALID_POST);
         }
         community.modifyPost(modifyPostRequest.getTitle(), modifyPostRequest.getContent());
+    }
+
+    public WriteCommentResponse writeComment(final User user, final long communityId, final WriteCommentRequest writeCommentRequest) {
+        final Community community = communityRepository.findByIdAndDeleteTimeIsNull(communityId);
+        if (community == null) {
+            throw new CommunityException(CommunityErrorResult.INVALID_POST);
+        }
+
+        int depth, commentGroup;
+        if (writeCommentRequest.getParentCommentId() != null) {
+            final Comment parentComment = commentRepository.findByIdAndCommunityIdAndDeleteTimeIsNull(writeCommentRequest.getParentCommentId(), communityId);
+            if (parentComment == null) {
+                throw new CommunityException(CommunityErrorResult.INVALID_COMMENT);
+            }
+            depth = parentComment.getDepth() + 1;
+            commentGroup = parentComment.getCommentGroup();
+        } else {
+            depth = 0;
+            commentGroup = commentRepository.countByCommunityIdAndDepth(communityId, 0);
+        }
+
+        final Comment comment = commentRepository.save(Comment.builder()
+                .communityId(communityId)
+                .parentCommentId(writeCommentRequest.getParentCommentId())
+                .commentContent(writeCommentRequest.getCommentContent())
+                .nickname(user.getNickname())
+                .depth(depth)
+                .commentGroup(commentGroup)
+                .build());
+
+        return WriteCommentResponse.builder()
+                .commentId(comment.getId())
+                .communityId(comment.getCommunityId())
+                .parentCommentId(comment.getParentCommentId())
+                .commentContent(comment.getCommentContent())
+                .nickname(comment.getNickname())
+                .depth(comment.getDepth())
+                .group(comment.getCommentGroup())
+                .createTime(localDateTimeToString(comment.getCreateTime()))
+                .build();
+    }
+
+    private String localDateTimeToString(final LocalDateTime time) {
+        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        return time.format(formatter);
     }
 
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/community/service/CommunityService.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/service/CommunityService.java
@@ -35,7 +35,7 @@ public class CommunityService {
 
     @Transactional
     public void modifyPost(final User user, final long communityId, final ModifyPostRequest modifyPostRequest) {
-        final Community community = communityRepository.findByIdAndNickname(communityId, user.getNickname());
+        final Community community = communityRepository.findByIdAndNicknameAndDeleteTimeIsNull(communityId, user.getNickname());
         if (community == null) {
             throw new CommunityException(CommunityErrorResult.INVALID_POST);
         }


### PR DESCRIPTION
close #25 

1. `Comment` 엔티티 생성했습니다.
    - `depth` 대댓글 깊이입니다. 댓글인 경우는 0 값을 갖습니다.
2. 댓글 작성 API를 구현했습니다.