### PR TITLE
[BE] 댓글 수정 API 구현

### DIFF
--- a/BE/src/main/java/com/twopilogue/intervyou/community/constant/CommunityConstant.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/constant/CommunityConstant.java
@@ -8,4 +8,5 @@ public class CommunityConstant {
     public static final String WRITE_POST_SUCCESS_MESSAGE = "게시글 작성이 완료되었습니다.";
     public static final String MODIFY_POST_SUCCESS_MESSAGE = "게시글 수정이 완료되었습니다.";
     public static final String WRITE_COMMENT_SUCCESS_MESSAGE = "댓글 등록이 완료되었습니다.";
+    public static final String MODIFY_COMMENT_SUCCESS_MESSAGE = "댓글 수정이 완료되었습니다.";
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/community/controller/CommunityController.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/controller/CommunityController.java
@@ -1,6 +1,7 @@
 package com.twopilogue.intervyou.community.controller;
 
 import com.twopilogue.intervyou.common.BaseResponse;
+import com.twopilogue.intervyou.community.dto.request.ModifyCommentRequest;
 import com.twopilogue.intervyou.community.dto.request.ModifyPostRequest;
 import com.twopilogue.intervyou.community.dto.request.WriteCommentRequest;
 import com.twopilogue.intervyou.community.dto.request.WritePostRequest;
@@ -43,5 +44,14 @@ public class CommunityController {
                                                      @PathVariable final long communityId,
                                                      @RequestBody @Valid final WriteCommentRequest writeCommentRequest) {
         return new ResponseEntity<>(BaseResponse.from(WRITE_COMMENT_SUCCESS_MESSAGE, communityService.writeComment(principalDetails.getUser(), communityId, writeCommentRequest)), HttpStatus.OK);
+    }
+
+    @PutMapping("/{communityId}/comments/{commentId}")
+    public ResponseEntity<BaseResponse> modifyComment(@AuthenticationPrincipal final PrincipalDetails principalDetails,
+                                                      @PathVariable final long communityId,
+                                                      @PathVariable final long commentId,
+                                                      @RequestBody @Valid final ModifyCommentRequest modifyCommentRequest) {
+        communityService.modifyComment(principalDetails.getUser(), communityId, commentId, modifyCommentRequest);
+        return new ResponseEntity<>(BaseResponse.from(MODIFY_COMMENT_SUCCESS_MESSAGE), HttpStatus.OK);
     }
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/community/dto/request/ModifyCommentRequest.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/dto/request/ModifyCommentRequest.java
@@ -1,0 +1,18 @@
+package com.twopilogue.intervyou.community.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ModifyCommentRequest {
+
+    @NotBlank
+    private String commentContent;
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/community/dto/response/WriteCommentResponse.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/dto/response/WriteCommentResponse.java
@@ -13,5 +13,5 @@ public class WriteCommentResponse {
     private String nickname;
     private String createTime;
     private int depth;
-    private int group;
+    private int commentGroup;
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/community/entity/Comment.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/entity/Comment.java
@@ -45,4 +45,8 @@ public class Comment {
 
     @Column(name = "delete_time")
     private LocalDateTime deleteTime;
+
+    public void modifyComment(final String commentContent) {
+        this.commentContent = commentContent;
+    }
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommentRepository.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommentRepository.java
@@ -7,5 +7,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Comment findByIdAndCommunityIdAndDeleteTimeIsNull(final long id, final long communityId);
+    Comment findByIdAndNicknameAndCommunityIdAndDeleteTimeIsNull(final long id, final String nickname, final long communityId);
     int countByCommunityIdAndDepth(final long communityId, final int depth);
 }


### PR DESCRIPTION
close #27 

1. 게시글 검증 로직을 `existValidCommunity` 메서드로 분리하여 재활용했습니다.