### PR TITLE
[BE] 댓글 삭제 API 구현

### DIFF
--- a/BE/src/main/java/com/twopilogue/intervyou/community/constant/CommunityConstant.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/constant/CommunityConstant.java
@@ -9,4 +9,5 @@ public class CommunityConstant {
     public static final String MODIFY_POST_SUCCESS_MESSAGE = "게시글 수정이 완료되었습니다.";
     public static final String WRITE_COMMENT_SUCCESS_MESSAGE = "댓글 등록이 완료되었습니다.";
     public static final String MODIFY_COMMENT_SUCCESS_MESSAGE = "댓글 수정이 완료되었습니다.";
+    public static final String REMOVE_COMMENT_SUCCESS_MESSAGE = "댓글 삭제가 완료되었습니다.";
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/community/controller/CommunityController.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/controller/CommunityController.java
@@ -54,4 +54,12 @@ public class CommunityController {
         communityService.modifyComment(principalDetails.getUser(), communityId, commentId, modifyCommentRequest);
         return new ResponseEntity<>(BaseResponse.from(MODIFY_COMMENT_SUCCESS_MESSAGE), HttpStatus.OK);
     }
+
+    @DeleteMapping("/{communityId}/comments/{commentId}")
+    public ResponseEntity<BaseResponse> removeComment(@AuthenticationPrincipal final PrincipalDetails principalDetails,
+                                                      @PathVariable final long communityId,
+                                                      @PathVariable final long commentId) {
+        communityService.removeComment(principalDetails.getUser(), communityId, commentId);
+        return new ResponseEntity<>(BaseResponse.from(REMOVE_COMMENT_SUCCESS_MESSAGE), HttpStatus.OK);
+    }
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/community/entity/Comment.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/entity/Comment.java
@@ -49,4 +49,8 @@ public class Comment {
     public void modifyComment(final String commentContent) {
         this.commentContent = commentContent;
     }
+
+    public void removeComment() {
+        this.deleteTime = LocalDateTime.now();
+    }
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/community/service/CommunityService.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/service/CommunityService.java
@@ -40,6 +40,14 @@ public class CommunityService {
         }
     }
 
+    private Comment findComment(final String nickname, final long commentId, final long communityId) {
+        final Comment comment = commentRepository.findByIdAndNicknameAndCommunityIdAndDeleteTimeIsNull(commentId, nickname, communityId);
+        if (comment == null) {
+            throw new CommunityException(CommunityErrorResult.INVALID_COMMENT);
+        }
+        return comment;
+    }
+
     public WritePostResponse writePost(final User user, final WritePostRequest writePostRequest) {
         final Community community = communityRepository.save(Community.builder()
                 .title(writePostRequest.getTitle())
@@ -99,11 +107,14 @@ public class CommunityService {
 
     public void modifyComment(final User user, final long communityId, final long commentId, final ModifyCommentRequest modifyCommentRequest) {
         existValidCommunity(communityId);
-        final Comment comment = commentRepository.findByIdAndNicknameAndCommunityIdAndDeleteTimeIsNull(commentId, user.getNickname(), communityId);
-        if (comment == null) {
-            throw new CommunityException(CommunityErrorResult.INVALID_COMMENT);
-        }
+        final Comment comment = findComment(user.getNickname(), commentId, communityId);
         comment.modifyComment(modifyCommentRequest.getCommentContent());
+    }
+
+    public void removeComment(final User user, final long communityId, final long commentId) {
+        existValidCommunity(communityId);
+        final Comment comment = findComment(user.getNickname(), commentId, communityId);
+        comment.removeComment();
     }
 
 }


### PR DESCRIPTION
close #29 

1. 댓글 조회 로직을 `findComment` 메서드로 분리하여 재활용했습니다.