### PR TITLE
[FE] 면접 시작 및 진행 페이지 컴포넌트 생성

### DIFF
--- a/FE/src/app/_components/button/Button.tsx
+++ b/FE/src/app/_components/button/Button.tsx
@@ -1,13 +1,11 @@
-import React, { ElementType } from "react";
+import React, { ButtonHTMLAttributes, ElementType, ReactNode } from "react";
 
-interface ButtonProps {
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: string | ReactNode;
   types?: "primary" | "secondary" | "gray";
   backgroundColor?: string;
   size?: "small" | "medium" | "large";
-  label: string;
-  onClick?: () => void;
   as?: ElementType;
-  href?: string;
 }
 
 const buttonConfig = {
@@ -35,20 +33,21 @@ const buttonConfig = {
 };
 
 export const Button = ({
+  children,
   types = "primary",
   size = "medium",
   backgroundColor,
-  label,
+
   as: Component = "button",
   ...props
 }: ButtonProps) => {
   return (
     <Component
       type="button"
-      className={`rounded-lg ${buttonConfig[size]} ${buttonConfig[types].bgColor} ${buttonConfig[types].color}`}
+      className={`min-h-10 rounded-lg ${buttonConfig[size]} ${buttonConfig[types].bgColor} ${buttonConfig[types].color}`}
       {...props}
     >
-      {label}
+      {children}
     </Component>
   );
 };

--- a/FE/src/app/_components/header/Header.tsx
+++ b/FE/src/app/_components/header/Header.tsx
@@ -9,7 +9,7 @@ const CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID;
 const link = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URL}&state=state`;
 
 export const Header = () => {
-  const [isLogin, setIsLogin] = useState(false);
+  const [isLogin, setIsLogin] = useState(true);
   const [open, setOpen] = useState(false);
   return (
     <>
@@ -36,7 +36,7 @@ export const Header = () => {
           <div className="flex gap-6 *:cursor-pointer max-sm:hidden">
             {isLogin ? (
               <>
-                <Link href="/interview">면접 시작</Link>
+                <Link href="/create">면접 시작</Link>
                 <Link href="/list">면접 내역</Link>
                 <Link href="/community">커뮤니티</Link>
                 <Link href="/mypage">마이페이지</Link>
@@ -63,7 +63,7 @@ export const Header = () => {
             <div className="flex flex-col gap-4 *:cursor-pointer">
               {isLogin ? (
                 <>
-                  <Link href="/interview">면접 시작</Link>
+                  <Link href="/create">면접 시작</Link>
                   <Link href="/list">면접 내역</Link>
                   <Link href="/community">커뮤니티</Link>
                   <Link href="/mypage">마이페이지</Link>

--- a/FE/src/app/_components/input/InputField.tsx
+++ b/FE/src/app/_components/input/InputField.tsx
@@ -1,7 +1,8 @@
-interface InputFieldProps {
+import { InputHTMLAttributes } from "react";
+
+interface InputFieldProps extends InputHTMLAttributes<HTMLInputElement> {
   name: string;
   label?: string;
-  placeholder?: string;
 }
 
 export const InputField = ({ name, label, ...props }: InputFieldProps) => {
@@ -13,7 +14,6 @@ export const InputField = ({ name, label, ...props }: InputFieldProps) => {
         </label>
       )}
       <input
-        name={name}
         type="text"
         className="w-full rounded-lg border border-gray-30 px-2.5 py-1.5 text-sm text-gray-90 outline-none focus:border-primary"
         {...props}

--- a/FE/src/app/_components/input/InputField.tsx
+++ b/FE/src/app/_components/input/InputField.tsx
@@ -8,17 +8,14 @@ export const InputField = ({ name, label, ...props }: InputFieldProps) => {
   return (
     <>
       {label && (
-        <label
-          htmlFor={name}
-          className="block mb-2 text-gray-90 text-sm font-bold"
-        >
+        <label htmlFor={name} className="mb-2 block text-sm font-bold text-gray-90">
           {label}
         </label>
       )}
       <input
         name={name}
         type="text"
-        className="w-full px-2.5 py-3 rounded-lg border border-gray-30 outline-none text-sm text-gray-90 focus:border-primary"
+        className="w-full rounded-lg border border-gray-30 px-2.5 py-1.5 text-sm text-gray-90 outline-none focus:border-primary"
         {...props}
       />
     </>

--- a/FE/src/app/_components/input/TextArea.tsx
+++ b/FE/src/app/_components/input/TextArea.tsx
@@ -1,25 +1,28 @@
-interface TextAreaProps {
+import { InputHTMLAttributes } from "react";
+
+interface TextAreaProps extends InputHTMLAttributes<HTMLTextAreaElement> {
   name: string;
   label?: string;
   placeholder: string;
+  onChange?: any;
 }
 
 export const TextArea = ({ name, label, ...props }: TextAreaProps) => {
   return (
-    <div>
+    <>
       {label && (
-        <label
-          className="block mb-2 text-gray-90 text-sm font-bold"
-          htmlFor={name}
-        >
+        <label className="mb-2 block text-sm font-bold text-gray-90" htmlFor={name}>
           {label}
         </label>
       )}
       <textarea
         id={name}
-        className="px-2.5 py-3 rounded-lg border border-gray-30 outline-none text-sm text-gray-90 focus:border-primary"
+        className="h-min w-full resize-none overflow-hidden rounded-lg border border-gray-30 px-2.5 py-2.5 text-sm text-gray-90 outline-none focus:border-primary"
+        rows={1}
         {...props}
       />
-    </div>
+    </>
   );
 };
+
+TextArea.displayName = "TextArea";

--- a/FE/src/app/content/_components/Bubble/index.tsx
+++ b/FE/src/app/content/_components/Bubble/index.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+interface Props {
+  content: string;
+  isMine: boolean;
+  isFinished: boolean;
+}
+
+export default function Bubble({ content, isMine, isFinished }: Props) {
+  return (
+    <div className={`${isMine && "self-end"} flex min-w-min max-w-xl flex-col gap-2`}>
+      <div className="flex items-end gap-2">
+        <div
+          className={`${isMine ? "order-2 rounded-tr-none bg-lightblue" : "order-1 rounded-tl-none bg-secondary"} flex rounded-3xl p-5`}
+        >
+          <span className="text-sm">{content}</span>
+        </div>
+        {isFinished && (
+          <div
+            className={` ${isMine ? "order-1" : "order-2"} cursor-pointer rounded-full bg-gray-10 p-2 hover:bg-gray-20`}
+          >
+            <svg className="h-6 w-6 text-gray-70" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.5"
+                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+              />
+            </svg>
+          </div>
+        )}
+      </div>
+      <div className={`${isMine ? "self-end" : ""} text-xs text-gray-70`}>09:00</div>
+    </div>
+  );
+}

--- a/FE/src/app/content/_components/Header/index.tsx
+++ b/FE/src/app/content/_components/Header/index.tsx
@@ -1,0 +1,69 @@
+import { Modal } from "@mui/base";
+import Link from "next/link";
+import { useState } from "react";
+
+export default function ContentHeader({}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <div className="flex h-16 w-full items-center border-b border-gray-40 bg-white">
+        <div className="mx-4 flex w-full items-center justify-between">
+          <div className="flex items-center gap-2">
+            <svg className="h-6 w-6 cursor-pointer" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+            </svg>
+            <span className="text-lg font-bold">프론트엔드 모의 면접</span>
+          </div>
+          <div className="flex gap-4 sm:hidden">
+            <svg
+              className="h-6 w-6 cursor-pointer text-danger-text"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.5"
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              />
+            </svg>
+            <svg
+              onClick={() => setOpen(true)}
+              className="h-6 w-6 cursor-pointer text-gray-90"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </div>
+          <div className="flex gap-6 *:cursor-pointer max-sm:hidden">
+            <Link className="text-danger-text" href="/create">
+              면접 삭제
+            </Link>
+            <Link href="/list">면접 내역</Link>
+            <Link href="/community">커뮤니티</Link>
+            <Link href="/mypage">마이페이지</Link>
+          </div>
+        </div>
+      </div>
+      {open && (
+        <Modal open={open}>
+          <div className="absolute top-0 h-full w-full bg-white px-4 outline-none">
+            <div className="my-8 cursor-pointer" onClick={() => setOpen(false)}>
+              <svg className="h-6 w-6 text-gray-90" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </div>
+            <div className="flex flex-col gap-4 *:cursor-pointer">
+              <Link href="/list">면접 내역</Link>
+              <Link href="/community">커뮤니티</Link>
+              <Link href="/mypage">마이페이지</Link>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/FE/src/app/content/page.tsx
+++ b/FE/src/app/content/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Bubble from "./_components/Bubble";
+import { Button } from "../_components/button/Button";
+import { TextArea } from "../_components/input/TextArea";
+import { useState } from "react";
+
+export default function Content({}) {
+  const [input, setInput] = useState("");
+
+  return (
+    <>
+      <div className="flex h-[calc(100%-4rem-4rem)] flex-col overflow-y-auto p-4">
+        <Bubble isMine={false} isFinished={false} content="채팅 내용입니다." />
+        <Bubble isMine={true} isFinished={false} content="채팅 내용입니다." />
+        <Bubble isMine={false} isFinished={true} content="채팅 내용입니다." />
+        <Bubble isMine={true} isFinished={true} content="채팅 내용입니다." />
+      </div>
+      <div className="flex-glow fixed bottom-0 flex h-16 w-full justify-center gap-2 p-2">
+        <div className="w-full">
+          <TextArea
+            placeholder="내용을 입력하세요."
+            name="input"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+          />
+        </div>
+        <div className="flex-shrink-0">
+          {input.length > 0 ? (
+            <Button size="small">전송</Button>
+          ) : (
+            <Button size="medium">
+              <svg
+                className="h-6 w-6 text-white"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                strokeWidth="1.5"
+                stroke="currentColor"
+                fill="none"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path stroke="none" d="M0 0h24v24H0z" /> <circle cx="7" cy="12" r="3" />{" "}
+                <circle cx="17" cy="12" r="3" /> <line x1="7" y1="15" x2="17" y2="15" />
+              </svg>
+            </Button>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/FE/src/app/create/_components/CheckBox/index.tsx
+++ b/FE/src/app/create/_components/CheckBox/index.tsx
@@ -1,0 +1,19 @@
+import { ChangeEvent } from "react";
+
+interface CheckBoxProps {
+  id: string;
+  name: string;
+  value: number;
+  label: string;
+  checked?: boolean;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function CheckBox({ id, label, checked = false, ...props }: CheckBoxProps) {
+  return (
+    <label className="flex cursor-pointer items-center gap-1">
+      <input type="checkbox" checked={checked} {...props} />
+      <span className="text-sm text-gray-90"> {label}</span>
+    </label>
+  );
+}

--- a/FE/src/app/create/_components/Radio/index.tsx
+++ b/FE/src/app/create/_components/Radio/index.tsx
@@ -1,0 +1,19 @@
+import { ChangeEvent } from "react";
+
+interface RadioProps {
+  id: string;
+  name: string;
+  value: number;
+  label: string;
+  checked?: boolean;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function Radio({ id, label, checked = false, ...props }: RadioProps) {
+  return (
+    <label className="flex cursor-pointer items-center gap-1">
+      <input type="radio" checked={checked} {...props} />
+      <span className="text-sm text-gray-90"> {label}</span>
+    </label>
+  );
+}

--- a/FE/src/app/create/page.tsx
+++ b/FE/src/app/create/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { ChangeEvent, useState } from "react";
+import { InputField } from "../_components/input/InputField";
+import { Button } from "../_components/button/Button";
+import Radio from "./_components/Radio";
+import CheckBox from "./_components/CheckBox";
+
+export default function Create({}) {
+  const [selected, setSelected] = useState(1);
+
+  const handleRadio = (e: ChangeEvent<HTMLInputElement>) => {
+    setSelected(Number(e.target.value));
+  };
+
+  return (
+    <>
+      <div className="mb-4 flex w-full items-center bg-lightblue px-4 py-8">
+        <span>면접 시작하기</span>
+      </div>
+      <div className="mx-4 sm:flex sm:flex-row sm:gap-8">
+        <div className="sm:w-2/5">
+          <InputField name="job" label="직무" placeholder="직무를 작성해주세요." />
+        </div>
+        <div className="sm:w-3/5">
+          <div className="mb-4 max-sm:mt-8">
+            <span className="mb-2 block text-sm font-bold text-gray-90">질문 생성</span>
+            <div className="flex flex-row gap-4">
+              <Radio
+                id="rdo1"
+                name="rdo1"
+                value={1}
+                label="직접 입력"
+                checked={selected === 1}
+                onChange={handleRadio}
+              />
+              <Radio id="rdo2" name="rdo2" value={2} label="GPT 생성" checked={selected === 2} onChange={handleRadio} />
+            </div>
+          </div>
+          {selected === 1 ? (
+            <div className="flex w-full gap-2">
+              <div className="flex-grow">
+                <InputField name="question" placeholder="질문을 입력하세요." />
+                <span className="mt-1 block text-xs text-gray-60">
+                  최소 1개 ~ 최대 5개의 질문을 입력할 수 있습니다.
+                </span>
+              </div>
+              <div className="w-18 flex-shrink-0">
+                <Button size="small" label="추가" />
+              </div>
+            </div>
+          ) : (
+            <div>
+              <div className="mb-4">
+                <span className="mb-2 block text-sm font-bold text-gray-90">질문 수</span>
+                <select className="mb-1 w-full rounded-lg border border-gray-30 px-2 py-1.5 text-sm text-gray-90 outline-none focus:border-primary">
+                  {Array.from([1, 2, 3, 4, 5], (v: number, i: number) => {
+                    return (
+                      <option key={i} value={v}>
+                        {v}
+                      </option>
+                    );
+                  })}
+                </select>
+                <span className="block text-xs text-gray-60">최소 1개 ~ 최대 5개의 질문을 입력할 수 있습니다.</span>
+              </div>
+              <div>
+                <span className="mb-2 block text-sm font-bold text-gray-90">질문 생성</span>
+                <div className="flex flex-row gap-4">
+                  <CheckBox id="cb1" name="cb1" value={1} label="인성" />
+                  <CheckBox id="cb2" name="cb2" value={2} label="직무" />
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="absolute flex w-full justify-center gap-4 px-4 *:min-w-32 max-sm:bottom-4 sm:bottom-8">
+        <Button types="gray" label="취소" />
+        <Button types="primary" label="시작하기" />
+      </div>
+    </>
+  );
+}

--- a/FE/src/app/create/page.tsx
+++ b/FE/src/app/create/page.tsx
@@ -5,8 +5,10 @@ import { InputField } from "../_components/input/InputField";
 import { Button } from "../_components/button/Button";
 import Radio from "./_components/Radio";
 import CheckBox from "./_components/CheckBox";
+import { useRouter } from "next/navigation";
 
 export default function Create({}) {
+  const router = useRouter();
   const [selected, setSelected] = useState(1);
 
   const handleRadio = (e: ChangeEvent<HTMLInputElement>) => {
@@ -46,7 +48,7 @@ export default function Create({}) {
                 </span>
               </div>
               <div className="w-18 flex-shrink-0">
-                <Button size="small" label="추가" />
+                <Button size="small">추가</Button>
               </div>
             </div>
           ) : (
@@ -76,8 +78,8 @@ export default function Create({}) {
         </div>
       </div>
       <div className="absolute flex w-full justify-center gap-4 px-4 *:min-w-32 max-sm:bottom-4 sm:bottom-8">
-        <Button types="gray" label="취소" />
-        <Button types="primary" label="시작하기" />
+        <Button types="gray">취소</Button>
+        <Button onClick={() => router.push("/content")}>시작하기</Button>
       </div>
     </>
   );

--- a/FE/src/app/layout.tsx
+++ b/FE/src/app/layout.tsx
@@ -1,11 +1,16 @@
+"use client";
+
+import { usePathname } from "next/navigation";
 import "../styles/globals.css";
 import { Header } from "./_components/header/Header";
+import ContentHeader from "./content/_components/Header";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
   return (
     <html>
       <body className="h-svh w-svw">
-        <Header />
+        {pathname === "/content" ? <ContentHeader /> : <Header />}
         {children}
       </body>
     </html>

--- a/FE/stories/Button.stories.ts
+++ b/FE/stories/Button.stories.ts
@@ -26,41 +26,41 @@ type Story = StoryObj<typeof meta>;
 export const Primary: Story = {
   args: {
     types: "primary",
-    label: "Button",
+    children: "Button",
   },
 };
 
 export const Secondary: Story = {
   args: {
     types: "secondary",
-    label: "Button",
+    children: "Button",
   },
 };
 
 export const Gray: Story = {
   args: {
     types: "gray",
-    label: "Button",
+    children: "Button",
   },
 };
 
 export const Large: Story = {
   args: {
     size: "large",
-    label: "Button",
+    children: "Button",
   },
 };
 
 export const Medium: Story = {
   args: {
     size: "medium",
-    label: "Button",
+    children: "Button",
   },
 };
 
 export const Small: Story = {
   args: {
     size: "small",
-    label: "Button",
+    children: "Button",
   },
 };

--- a/FE/tailwind.config.js
+++ b/FE/tailwind.config.js
@@ -22,6 +22,7 @@ export const theme = {
       70: "#555555",
       90: "#1D1D1D",
     },
+    lightblue: "#EBF6FF",
   },
   extend: {
     fontFamily: {


### PR DESCRIPTION
close #10 

### 1. 면접 시작 페이지 생성
- 모바일 시 세로, PC화면 시 2단으로 보여짐.
- 질문이 추가되면서 하단 list 생성되는 컴포넌트는 추후 추가할 예정 !

### 2. 면접 진행 페이지 생성
- textarea의 컨텐츠가 늘어나면 그에 따라 채팅 내용의 스크롤이 줄어들도록 수정 예정 !

