### PR TITLE
[BE] 게시글 삭제 API 구현

### DIFF
--- a/BE/src/main/java/com/twopilogue/intervyou/community/constant/CommunityConstant.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/constant/CommunityConstant.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 public class CommunityConstant {
     public static final String WRITE_POST_SUCCESS_MESSAGE = "게시글 작성이 완료되었습니다.";
     public static final String MODIFY_POST_SUCCESS_MESSAGE = "게시글 수정이 완료되었습니다.";
+    public static final String REMOVE_POST_SUCCESS_MESSAGE = "게시글 삭제가 완료되었습니다.";
     public static final String WRITE_COMMENT_SUCCESS_MESSAGE = "댓글 등록이 완료되었습니다.";
     public static final String MODIFY_COMMENT_SUCCESS_MESSAGE = "댓글 수정이 완료되었습니다.";
     public static final String REMOVE_COMMENT_SUCCESS_MESSAGE = "댓글 삭제가 완료되었습니다.";

--- a/BE/src/main/java/com/twopilogue/intervyou/community/controller/CommunityController.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/controller/CommunityController.java
@@ -39,6 +39,13 @@ public class CommunityController {
         return new ResponseEntity<>(BaseResponse.from(MODIFY_POST_SUCCESS_MESSAGE), HttpStatus.OK);
     }
 
+    @DeleteMapping("/{communityId}")
+    public ResponseEntity<BaseResponse> removePost(@AuthenticationPrincipal final PrincipalDetails principalDetails,
+                                                   @PathVariable final long communityId) {
+        communityService.removePost(principalDetails.getUser(), communityId);
+        return new ResponseEntity<>(BaseResponse.from(REMOVE_POST_SUCCESS_MESSAGE), HttpStatus.OK);
+    }
+
     @PostMapping("/{communityId}/comments")
     public ResponseEntity<BaseResponse> writeComment(@AuthenticationPrincipal final PrincipalDetails principalDetails,
                                                      @PathVariable final long communityId,

--- a/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommentRepository.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommentRepository.java
@@ -2,11 +2,20 @@ package com.twopilogue.intervyou.community.repositiry;
 
 import com.twopilogue.intervyou.community.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Comment findByIdAndCommunityIdAndDeleteTimeIsNull(final long id, final long communityId);
     Comment findByIdAndNicknameAndCommunityIdAndDeleteTimeIsNull(final long id, final String nickname, final long communityId);
     int countByCommunityIdAndDepth(final long communityId, final int depth);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Comment c set c.deleteTime = :deleteTime where c.communityId = :communityId and c.deleteTime is null")
+    void deleteAllByCommunityId(@Param("communityId") final long communityId, @Param("deleteTime") final LocalDateTime time);
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommunityRepository.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommunityRepository.java
@@ -2,10 +2,20 @@ package com.twopilogue.intervyou.community.repositiry;
 
 import com.twopilogue.intervyou.community.entity.Community;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
 
 @Repository
 public interface CommunityRepository extends JpaRepository<Community, Long> {
     Community findByIdAndNicknameAndDeleteTimeIsNull(final long id, final String nickname);
     Community findByIdAndDeleteTimeIsNull(final long id);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Community c set c.deleteTime = :deleteTime where c.id = :communityId")
+    void deleteByCommunityId(@Param("communityId") final long communityId, @Param("deleteTime") final LocalDateTime time);
+
 }


### PR DESCRIPTION
close #33 

1. 게시글 조회 로직을 `findCommunity` 메서드로 분리하여 재활용했습니다.
2. 게시글 삭제 시 해당 게시글과 관련된 댓글들을 모두 삭제 처리하였습니다.