### PR TITLE
[BE] 게시글 조회 API 구현

### DIFF
--- a/BE/src/main/java/com/twopilogue/intervyou/community/constant/CommunityConstant.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/constant/CommunityConstant.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommunityConstant {
     public static final String WRITE_POST_SUCCESS_MESSAGE = "게시글 작성이 완료되었습니다.";
+    public static final String READ_POST_SUCCESS_MESSAGE = "게시글 조회가 완료되었습니다.";
     public static final String MODIFY_POST_SUCCESS_MESSAGE = "게시글 수정이 완료되었습니다.";
     public static final String REMOVE_POST_SUCCESS_MESSAGE = "게시글 삭제가 완료되었습니다.";
     public static final String WRITE_COMMENT_SUCCESS_MESSAGE = "댓글 등록이 완료되었습니다.";

--- a/BE/src/main/java/com/twopilogue/intervyou/community/controller/CommunityController.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/controller/CommunityController.java
@@ -31,6 +31,11 @@ public class CommunityController {
         return new ResponseEntity<>(BaseResponse.from(WRITE_POST_SUCCESS_MESSAGE, communityService.writePost(principalDetails.getUser(), writePostRequest)), HttpStatus.OK);
     }
 
+    @GetMapping("/{communityId}")
+    public ResponseEntity<BaseResponse> readPost(@PathVariable final long communityId) {
+        return new ResponseEntity<>(BaseResponse.from(READ_POST_SUCCESS_MESSAGE, communityService.readPost(communityId)), HttpStatus.OK);
+    }
+
     @PutMapping("/{communityId}")
     public ResponseEntity<BaseResponse> modifyPost(@AuthenticationPrincipal final PrincipalDetails principalDetails,
                                                    @PathVariable final long communityId,

--- a/BE/src/main/java/com/twopilogue/intervyou/community/dto/response/CommentResponse.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/dto/response/CommentResponse.java
@@ -1,0 +1,16 @@
+package com.twopilogue.intervyou.community.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CommentResponse {
+    private Boolean isDelete;
+    private Long commentId;
+    private String nickname;
+    private String commentContent;
+    private String createTime;
+    private Long parentCommentId;
+    private int depth;
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/community/dto/response/PostResponse.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/dto/response/PostResponse.java
@@ -1,0 +1,18 @@
+package com.twopilogue.intervyou.community.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PostResponse {
+    private long communityId;
+    private String title;
+    private String content;
+    private String nickname;
+    private String createTime;
+    private int commentCount;
+    private List<CommentResponse> comments;
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/community/exception/CommunityErrorResult.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/exception/CommunityErrorResult.java
@@ -11,6 +11,7 @@ public enum CommunityErrorResult implements BaseErrorResult {
 
     INVALID_POST(HttpStatus.BAD_REQUEST, "유효하지 않은 게시글입니다."),
     INVALID_COMMENT(HttpStatus.BAD_REQUEST, "유효하지 않은 댓글입니다."),
+    REMOVED_POST(HttpStatus.BAD_REQUEST, "삭제된 게시글입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommentRepository.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommentRepository.java
@@ -8,11 +8,13 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Comment findByIdAndCommunityIdAndDeleteTimeIsNull(final long id, final long communityId);
     Comment findByIdAndNicknameAndCommunityIdAndDeleteTimeIsNull(final long id, final String nickname, final long communityId);
+    List<Comment> findAllByCommunityIdAndParentCommentIdOrderByCreateTime(final long communityId, final Long parentCommentId);
     int countByCommunityIdAndDepth(final long communityId, final int depth);
 
     @Modifying(clearAutomatically = true)

--- a/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommunityRepository.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommunityRepository.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 public interface CommunityRepository extends JpaRepository<Community, Long> {
     Community findByIdAndNicknameAndDeleteTimeIsNull(final long id, final String nickname);
     Community findByIdAndDeleteTimeIsNull(final long id);
+    boolean existsByIdAndDeleteTimeIsNull(final long id);
 
     @Modifying(clearAutomatically = true)
     @Query("update Community c set c.deleteTime = :deleteTime where c.id = :communityId")

--- a/BE/src/main/java/com/twopilogue/intervyou/community/service/CommunityService.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/service/CommunityService.java
@@ -34,8 +34,7 @@ public class CommunityService {
     }
 
     private void existValidCommunity(final long communityId) {
-        final Community community = communityRepository.findByIdAndDeleteTimeIsNull(communityId);
-        if (community == null) {
+        if (!communityRepository.existsByIdAndDeleteTimeIsNull(communityId)) {
             throw new CommunityException(CommunityErrorResult.INVALID_POST);
         }
     }

--- a/BE/src/main/java/com/twopilogue/intervyou/community/service/CommunityService.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/service/CommunityService.java
@@ -4,6 +4,8 @@ import com.twopilogue.intervyou.community.dto.request.ModifyCommentRequest;
 import com.twopilogue.intervyou.community.dto.request.ModifyPostRequest;
 import com.twopilogue.intervyou.community.dto.request.WriteCommentRequest;
 import com.twopilogue.intervyou.community.dto.request.WritePostRequest;
+import com.twopilogue.intervyou.community.dto.response.CommentResponse;
+import com.twopilogue.intervyou.community.dto.response.PostResponse;
 import com.twopilogue.intervyou.community.dto.response.WriteCommentResponse;
 import com.twopilogue.intervyou.community.dto.response.WritePostResponse;
 import com.twopilogue.intervyou.community.entity.Comment;
@@ -19,6 +21,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -66,6 +72,49 @@ public class CommunityService {
                 .communityId(community.getId())
                 .build();
 
+    }
+
+    public PostResponse readPost(final long communityId) {
+        final Optional<Community> community_opt = communityRepository.findById(communityId);
+        if (!community_opt.isPresent()) {
+            throw new CommunityException(CommunityErrorResult.INVALID_POST);
+        }
+
+        final Community community = community_opt.get();
+        if (community.getDeleteTime() != null) {
+            throw new CommunityException(CommunityErrorResult.REMOVED_POST);
+        }
+
+        final List<Comment> comments = findComments(communityId, null);
+        return PostResponse.builder()
+                .communityId(community.getId())
+                .title(community.getTitle())
+                .content(community.getContent())
+                .nickname(community.getNickname())
+                .createTime(localDateTimeToString(community.getCreateTime()))
+                .commentCount(comments.size())
+                .comments(comments.stream()
+                        .map(comment -> CommentResponse.builder()
+                                .isDelete(comment.getDeleteTime() != null)
+                                .commentId(comment.getDeleteTime() == null ? comment.getId() : null)
+                                .nickname(comment.getDeleteTime() == null ? comment.getNickname() : null)
+                                .commentContent(comment.getDeleteTime() == null ? comment.getCommentContent() : null)
+                                .createTime(comment.getDeleteTime() == null ? localDateTimeToString(comment.getCreateTime()) : null)
+                                .parentCommentId(comment.getDeleteTime() == null ? comment.getParentCommentId() : null)
+                                .depth(comment.getDepth())
+                                .build())
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    private List<Comment> findComments(final long communityId, final Long parentCommentId) {
+        final List<Comment> comments = new ArrayList<>();
+        final List<Comment> commentList = commentRepository.findAllByCommunityIdAndParentCommentIdOrderByCreateTime(communityId, parentCommentId);
+        for (Comment comment : commentList) {
+            comments.add(comment);
+            comments.addAll(findComments(communityId, comment.getId()));
+        }
+        return comments;
     }
 
     public void modifyPost(final User user, final long communityId, final ModifyPostRequest modifyPostRequest) {


### PR DESCRIPTION
close #41 

1. 게시글 조회 시 응답값에 댓글도 포함시켰습니다.
    - 댓글은 `depth`에 따라 대댓글을 구분할 수 있도록 구현했습니다.
