### PR TITLE
[BE] 게시글 목록 조회 API 구현

### DIFF
--- a/BE/src/main/java/com/twopilogue/intervyou/community/constant/CommunityConstant.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/constant/CommunityConstant.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommunityConstant {
+    public static final String READ_POST_LIST_SUCCESS_MESSAGE = "게시글 목록 조회가 완료되었습니다.";
     public static final String WRITE_POST_SUCCESS_MESSAGE = "게시글 작성이 완료되었습니다.";
     public static final String READ_POST_SUCCESS_MESSAGE = "게시글 조회가 완료되었습니다.";
     public static final String MODIFY_POST_SUCCESS_MESSAGE = "게시글 수정이 완료되었습니다.";

--- a/BE/src/main/java/com/twopilogue/intervyou/community/controller/CommunityController.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/controller/CommunityController.java
@@ -25,6 +25,12 @@ public class CommunityController {
 
     private final CommunityService communityService;
 
+    @GetMapping("")
+    public ResponseEntity<BaseResponse> readPostList(@RequestParam int page,
+                                                     @RequestParam(defaultValue = "") final String keyword) {
+        return new ResponseEntity<>(BaseResponse.from(READ_POST_LIST_SUCCESS_MESSAGE, communityService.readPostList(page, keyword)), HttpStatus.OK);
+    }
+
     @PostMapping
     public ResponseEntity<BaseResponse> writePost(@AuthenticationPrincipal final PrincipalDetails principalDetails,
                                                   @RequestBody @Valid final WritePostRequest writePostRequest) {

--- a/BE/src/main/java/com/twopilogue/intervyou/community/dto/response/PostListDtoResponse.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/dto/response/PostListDtoResponse.java
@@ -1,0 +1,15 @@
+package com.twopilogue.intervyou.community.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PostListDtoResponse {
+    private long communityId;
+    private String title;
+    private String content;
+    private String nickname;
+    private String createTime;
+    private int commentCount;
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/community/dto/response/PostListResponse.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/dto/response/PostListResponse.java
@@ -1,0 +1,13 @@
+package com.twopilogue.intervyou.community.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PostListResponse {
+    private int totalPages;
+    private List<PostListDtoResponse> communities;
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommentRepository.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommentRepository.java
@@ -16,6 +16,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Comment findByIdAndNicknameAndCommunityIdAndDeleteTimeIsNull(final long id, final String nickname, final long communityId);
     List<Comment> findAllByCommunityIdAndParentCommentIdOrderByCreateTime(final long communityId, final Long parentCommentId);
     int countByCommunityIdAndDepth(final long communityId, final int depth);
+    int countByCommunityId(final long communityId);
 
     @Modifying(clearAutomatically = true)
     @Query("update Comment c set c.deleteTime = :deleteTime where c.communityId = :communityId and c.deleteTime is null")

--- a/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommunityRepository.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommunityRepository.java
@@ -15,9 +15,10 @@ import java.time.LocalDateTime;
 public interface CommunityRepository extends JpaRepository<Community, Long> {
     Community findByIdAndNicknameAndDeleteTimeIsNull(final long id, final String nickname);
     boolean existsByIdAndDeleteTimeIsNull(final long id);
+    Page<Community> findAll(final Pageable pageable);
 
     @Query("select c from Community c where Function('replace', c.title, ' ', '') like %:title%")
-    Page<Community> findAllByTitle(Pageable pageable, @Param("title") final String title);
+    Page<Community> findAllByTitle(final Pageable pageable, @Param("title") final String title);
 
     @Modifying(clearAutomatically = true)
     @Query("update Community c set c.deleteTime = :deleteTime where c.id = :communityId")

--- a/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommunityRepository.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/repositiry/CommunityRepository.java
@@ -1,6 +1,8 @@
 package com.twopilogue.intervyou.community.repositiry;
 
 import com.twopilogue.intervyou.community.entity.Community;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -13,6 +15,9 @@ import java.time.LocalDateTime;
 public interface CommunityRepository extends JpaRepository<Community, Long> {
     Community findByIdAndNicknameAndDeleteTimeIsNull(final long id, final String nickname);
     boolean existsByIdAndDeleteTimeIsNull(final long id);
+
+    @Query("select c from Community c where Function('replace', c.title, ' ', '') like %:title%")
+    Page<Community> findAllByTitle(Pageable pageable, @Param("title") final String title);
 
     @Modifying(clearAutomatically = true)
     @Query("update Community c set c.deleteTime = :deleteTime where c.id = :communityId")

--- a/BE/src/main/java/com/twopilogue/intervyou/community/service/CommunityService.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/service/CommunityService.java
@@ -75,9 +75,15 @@ public class CommunityService {
     }
 
     public PostListResponse readPostList(int page, String keyword) {
-        PageRequest pageRequest = PageRequest.of(page <= 0 ? 0 : page - 1, 10, Sort.by(Sort.Direction.DESC, "id"));
+        final PageRequest pageRequest = PageRequest.of(page <= 0 ? 0 : page - 1, 10, Sort.by(Sort.Direction.DESC, "id"));
         keyword = keyword.replaceAll(" ", "");
-        final Page<Community> postList = communityRepository.findAllByTitle(pageRequest, keyword);
+
+        Page<Community> postList;
+        if (keyword.equals("")) {
+            postList = communityRepository.findAll(pageRequest);
+        } else {
+            postList = communityRepository.findAllByTitle(pageRequest, keyword);
+        }
 
         return PostListResponse.builder()
                 .totalPages(postList.getTotalPages())

--- a/BE/src/main/java/com/twopilogue/intervyou/community/service/CommunityService.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/community/service/CommunityService.java
@@ -5,6 +5,8 @@ import com.twopilogue.intervyou.community.dto.request.ModifyPostRequest;
 import com.twopilogue.intervyou.community.dto.request.WriteCommentRequest;
 import com.twopilogue.intervyou.community.dto.request.WritePostRequest;
 import com.twopilogue.intervyou.community.dto.response.CommentResponse;
+import com.twopilogue.intervyou.community.dto.response.PostListDtoResponse;
+import com.twopilogue.intervyou.community.dto.response.PostListResponse;
 import com.twopilogue.intervyou.community.dto.response.PostResponse;
 import com.twopilogue.intervyou.community.entity.Comment;
 import com.twopilogue.intervyou.community.entity.Community;
@@ -14,6 +16,9 @@ import com.twopilogue.intervyou.community.repositiry.CommentRepository;
 import com.twopilogue.intervyou.community.repositiry.CommunityRepository;
 import com.twopilogue.intervyou.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -67,6 +72,25 @@ public class CommunityService {
             comments.addAll(findComments(communityId, comment.getId()));
         }
         return comments;
+    }
+
+    public PostListResponse readPostList(int page, String keyword) {
+        PageRequest pageRequest = PageRequest.of(page <= 0 ? 0 : page - 1, 10, Sort.by(Sort.Direction.DESC, "id"));
+        keyword = keyword.replaceAll(" ", "");
+        final Page<Community> postList = communityRepository.findAllByTitle(pageRequest, keyword);
+
+        return PostListResponse.builder()
+                .totalPages(postList.getTotalPages())
+                .communities(postList.map(post -> PostListDtoResponse.builder()
+                                .communityId(post.getId())
+                                .title(post.getTitle())
+                                .content(post.getContent())
+                                .nickname(post.getNickname())
+                                .createTime(localDateTimeToString(post.getCreateTime()))
+                                .commentCount(commentRepository.countByCommunityId(post.getId()))
+                                .build())
+                        .toList())
+                .build();
     }
 
     public PostResponse writePost(final User user, final WritePostRequest writePostRequest) {


### PR DESCRIPTION
close #47 

1. `Pageable`을 활용하여 게시글 목록 조회를 구현했습니다.
2. 키워드 검색 시 sql의 `like`구문을 활용했습니다.