### PR TITLE
[FE] 마이페이지 컴포넌트 생성

### DIFF
--- a/FE/src/app/board/detail/[pageId]/page.tsx
+++ b/FE/src/app/board/detail/[pageId]/page.tsx
@@ -7,7 +7,7 @@ import CommentItem from "../CommentItem";
 export default function BoardDetail({}) {
   const [comment, setComment] = useState("");
   return (
-    <div className="flex h-full w-full flex-col overflow-y-auto *:mx-auto *:w-full *:max-w-[1440px]">
+    <div className="flex h-full w-full flex-col overflow-y-auto *:mx-auto *:w-full *:max-w-[1280px]">
       <div className="flex flex-col gap-2 border-b border-gray-40 p-4">
         <span className="text-base font-bold text-gray-90">GPT가 이런 질문을 했는데요. (제목)</span>
         <div className="flex justify-between *:text-xs *:text-gray-50">

--- a/FE/src/app/board/page.tsx
+++ b/FE/src/app/board/page.tsx
@@ -9,9 +9,9 @@ import Pagination from "./Pagination";
 export default function Board({}) {
   const router = useRouter();
   return (
-    <div className="flex h-full flex-col *:mx-auto *:w-full [&>*:not(:nth-child(1))]:max-w-[1440px]">
+    <div className="flex h-full flex-col *:mx-auto *:w-full [&>*:not(:nth-child(1))]:max-w-[1280px]">
       <div className="mx-auto mb-4 flex w-full items-center bg-lightblue px-4 py-8">
-        <div className="mx-auto w-full max-w-[1440px] px-4">
+        <div className="mx-auto w-full max-w-[1280px] px-4">
           <span className="font-bold">커뮤니티</span>
         </div>
       </div>

--- a/FE/src/app/chat/page.tsx
+++ b/FE/src/app/chat/page.tsx
@@ -9,7 +9,7 @@ export default function ChatDetails({}) {
   const [input, setInput] = useState("");
 
   return (
-    <>
+    <div className="mx-auto max-w-[1024px]">
       <div className="flex h-[calc(100%-4rem-4rem)] flex-col overflow-y-auto p-4">
         <Bubble isMine={false} isFinished={false} content="채팅 내용입니다." />
         <Bubble isMine={true} isFinished={false} content="채팅 내용입니다." />
@@ -48,6 +48,6 @@ export default function ChatDetails({}) {
           )}
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/FE/src/app/mypage/details/comment/CommentItem.tsx
+++ b/FE/src/app/mypage/details/comment/CommentItem.tsx
@@ -1,0 +1,9 @@
+export default function CommentItem({}) {
+  return (
+    <div className="flex cursor-pointer flex-col gap-2 rounded-2xl border border-gray-30 p-6">
+      <span className="text-xs text-gray-50">2024/06/25(날짜)</span>
+      <span className="text-sm text-gray-90">정답은 없습니다.</span>
+      <span className="text-xs text-gray-50">GPT가 이런 질문을 했는데요. (제목)</span>
+    </div>
+  );
+}

--- a/FE/src/app/mypage/details/comment/page.tsx
+++ b/FE/src/app/mypage/details/comment/page.tsx
@@ -1,0 +1,14 @@
+import CommentItem from "./CommentItem";
+
+export default function MyPageComment() {
+  return (
+    <div className="mb-8 flex flex-col gap-4 overflow-y-auto px-4">
+      <CommentItem />
+      <CommentItem />
+      <CommentItem />
+      <CommentItem />
+      <CommentItem />
+      <CommentItem />
+    </div>
+  );
+}

--- a/FE/src/app/mypage/details/layout.tsx
+++ b/FE/src/app/mypage/details/layout.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+
+export default function MyPageDetailLayout({ children }) {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  return (
+    <>
+      <div className="flex h-full flex-col *:mx-auto *:w-full *:max-w-[1280px]">
+        <div className="flex items-center gap-2 px-4 py-8">
+          <svg
+            className="h-6 w-6 cursor-pointer"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            onClick={() => router.push("/mypage")}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          <span className="font-bold">{pathname.includes("/post") ? "내가 작성한 게시글" : "내가 작성한 댓글"}</span>
+        </div>
+        {children}
+      </div>
+    </>
+  );
+}

--- a/FE/src/app/mypage/details/post/PostItem.tsx
+++ b/FE/src/app/mypage/details/post/PostItem.tsx
@@ -1,0 +1,9 @@
+export default function PostItem({}) {
+  return (
+    <div className="flex cursor-pointer flex-col gap-2 rounded-2xl border border-gray-30 p-6">
+      <span className="text-xs text-gray-50">2024/06/25(날짜)</span>
+      <span className="text-base font-bold text-gray-90">GPT가 이런 질문을 했는데요. (제목)</span>
+      <span className="text-sm text-gray-70">어떤 답변이 가장 좋은 답변일까요? (내용)</span>
+    </div>
+  );
+}

--- a/FE/src/app/mypage/details/post/page.tsx
+++ b/FE/src/app/mypage/details/post/page.tsx
@@ -1,0 +1,14 @@
+import PostItem from "./PostItem";
+
+export default function MyPagePost() {
+  return (
+    <div className="mb-8 flex flex-col gap-4 overflow-y-auto px-4">
+      <PostItem />
+      <PostItem />
+      <PostItem />
+      <PostItem />
+      <PostItem />
+      <PostItem />
+    </div>
+  );
+}

--- a/FE/src/app/mypage/page.tsx
+++ b/FE/src/app/mypage/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+interface MenuTapProps extends HTMLElement {
+  title: string;
+  isLink?: boolean;
+  onClick: () => void;
+}
+
+const MenuTab = ({ title, isLink = true, ...props }) => {
+  return (
+    <div className="flex cursor-pointer justify-between" {...props}>
+      <span>{title}</span>
+      {isLink && (
+        <svg className="h-5 w-5 text-gray-60" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M9 5l7 7-7 7" />
+        </svg>
+      )}
+    </div>
+  );
+};
+
+export default function MyPage({}) {
+  const router = useRouter();
+  return (
+    <div className="flex h-full flex-col *:mx-auto *:w-full *:max-w-[1280px]">
+      <div className="mx-auto flex w-full items-center border-b border-gray-40 py-8">
+        <div className="mx-auto w-full max-w-[1280px] px-4">
+          <span className="font-bold">닉네임 </span>
+          <span>님</span>
+        </div>
+      </div>
+      <div className="flex flex-col *:border-b *:border-gray-20 *:p-4 *:text-sm [&>*:last-child]:border-gray-40">
+        <MenuTab title="내가 작성한 게시글" onClick={() => router.push("/mypage/details/post")} />
+        <MenuTab title="내가 작성한 댓글" onClick={() => router.push("/mypage/details/comment")} />
+      </div>
+      <div className="flex flex-col *:border-b *:border-gray-20 *:p-4 *:text-sm [&>*:last-child]:border-gray-40">
+        {/* <div>
+          <span>다크모드</span>
+        </div> */}
+        <MenuTab title="로그아웃" isLink={false} />
+        <MenuTab title="회원탈퇴" isLink={false} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
close #57 

### 1. 마이페이지 컴포넌트 생성
- /mypage로 들어간 후 "내가 작성한 게시글" 또는 "내가 작성한 댓글"로 이동시키는데, 두 경로가 동일한 layout을 가져가는 식이라, 어떻게 경로를 설정해야 할지 고민했다.
- /details 라는 공통 경로를 만든 후, 여기에 "layout.tsx" 컴포넌트를 만들고, 각각 /details/post, /details/comment로 경로를 설정해줬다. layout에 공통으로 들어가는 프레임 (뒤로가기 버튼+제목)을 만들고, 하위 /post/pages.tsx, /comment/pages.tsx에 각각의 컴포넌트를 만들었다.
- 여기서 react의 spa방식(csr)과 확실히 다름을 느꼈다. react만 사용했을 땐 경로 이동 없이 컴포넌트만 변경해주는 식으로 렌더링했을텐데, next를 이용하니 경로 이동에 따라 컴포넌트가 변경되기 때문에 ssg와 가깝다는 것을 체감했다.
