### PR TITLE
[BE] 채팅방 생성 API 구현

### DIFF
--- a/BE/src/main/java/com/twopilogue/intervyou/common/GlobalExceptionHandler.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/common/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.twopilogue.intervyou.common;
 
 import com.twopilogue.intervyou.community.exception.CommunityException;
+import com.twopilogue.intervyou.interview.exception.InterviewException;
 import com.twopilogue.intervyou.user.exception.UserException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
@@ -42,14 +43,20 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler({UserException.class})
-    public ResponseEntity<ErrorResponse> handleAuthException(final UserException exception) {
+    public ResponseEntity<ErrorResponse> handleUserException(final UserException exception) {
         log.warn("UserException occur: ", exception);
         return this.makeErrorResponseEntity(exception.getErrorResult());
     }
 
     @ExceptionHandler({CommunityException.class})
-    public ResponseEntity<ErrorResponse> handlePlannerSettingException(final CommunityException exception) {
+    public ResponseEntity<ErrorResponse> handleCommunityException(final CommunityException exception) {
         log.warn("CommunityException occur: ", exception);
+        return this.makeErrorResponseEntity(exception.getErrorResult());
+    }
+
+    @ExceptionHandler({InterviewException.class})
+    public ResponseEntity<ErrorResponse> handleInterviewException(final InterviewException exception) {
+        log.warn("InterviewException occur: ", exception);
         return this.makeErrorResponseEntity(exception.getErrorResult());
     }
 

--- a/BE/src/main/java/com/twopilogue/intervyou/config/OpenAiConfig.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/config/OpenAiConfig.java
@@ -1,0 +1,27 @@
+package com.twopilogue.intervyou.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import static com.twopilogue.intervyou.config.constant.ConfigConstant.HEADER_STRING;
+import static com.twopilogue.intervyou.config.constant.ConfigConstant.TOKEN_PREFIX;
+
+@Configuration
+public class OpenAiConfig {
+
+    @Value("${openai.api.secret-key}")
+    private String openAiKey;
+
+    @Bean
+    public RestTemplate template() {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.getInterceptors().add((request, body, execution) -> {
+            request.getHeaders().add(HEADER_STRING, TOKEN_PREFIX + openAiKey);
+            return execution.execute(request, body);
+        });
+        return restTemplate;
+    }
+
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/interview/constant/InterviewConstant.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/interview/constant/InterviewConstant.java
@@ -1,0 +1,9 @@
+package com.twopilogue.intervyou.interview.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class InterviewConstant {
+    public static final String START_INTERVIEW_SUCCESS_MESSAGE = "면접이 시작되었습니다.";
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/interview/controller/InterviewController.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/interview/controller/InterviewController.java
@@ -1,0 +1,31 @@
+package com.twopilogue.intervyou.interview.controller;
+
+import com.twopilogue.intervyou.common.BaseResponse;
+import com.twopilogue.intervyou.config.auth.PrincipalDetails;
+import com.twopilogue.intervyou.interview.dto.request.StartInterviewRequest;
+import com.twopilogue.intervyou.interview.service.InterviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+import static com.twopilogue.intervyou.interview.constant.InterviewConstant.START_INTERVIEW_SUCCESS_MESSAGE;
+
+@CrossOrigin("*")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/interview")
+public class InterviewController {
+
+    private final InterviewService interviewService;
+
+    @PostMapping("")
+    public ResponseEntity<BaseResponse> startInterview(@AuthenticationPrincipal final PrincipalDetails principalDetails,
+                                                       @Valid @RequestBody StartInterviewRequest startInterviewRequest) {
+        return new ResponseEntity<>(BaseResponse.from(START_INTERVIEW_SUCCESS_MESSAGE, interviewService.startInterview(principalDetails.getUser(), startInterviewRequest)), HttpStatus.OK);
+
+    }
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/interview/dto/chatgpt/ChatGPTRequest.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/interview/dto/chatgpt/ChatGPTRequest.java
@@ -1,0 +1,16 @@
+package com.twopilogue.intervyou.interview.dto.chatgpt;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ChatGPTRequest {
+    private String model;
+    private List<Message> messages;
+
+    public ChatGPTRequest(String model, List<Message> messages) {
+        this.model = model;
+        this.messages = messages;
+    }
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/interview/dto/chatgpt/ChatGPTResponse.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/interview/dto/chatgpt/ChatGPTResponse.java
@@ -1,0 +1,25 @@
+package com.twopilogue.intervyou.interview.dto.chatgpt;
+
+import com.twopilogue.intervyou.interview.dto.chatgpt.Message;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ChatGPTResponse {
+    private List<Choice> choices;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Choice {
+        private int index;
+        private Message message;
+    }
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/interview/dto/chatgpt/Message.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/interview/dto/chatgpt/Message.java
@@ -1,0 +1,15 @@
+package com.twopilogue.intervyou.interview.dto.chatgpt;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class Message {
+    private String role;
+    private String content;
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/interview/dto/request/StartInterviewRequest.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/interview/dto/request/StartInterviewRequest.java
@@ -1,0 +1,22 @@
+package com.twopilogue.intervyou.interview.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+
+@Getter
+@Builder
+public class StartInterviewRequest {
+
+    @NotBlank
+    String job;
+
+    @NotBlank
+    String questionType;
+
+    int questionCount;
+    int InterviewType;
+    List<String> questionList;
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/interview/dto/response/InterviewResponse.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/interview/dto/response/InterviewResponse.java
@@ -1,0 +1,12 @@
+package com.twopilogue.intervyou.interview.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class InterviewResponse {
+    private int sequence;
+    private String content;
+    private String createTime;
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/interview/dto/response/StartInterviewResponse.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/interview/dto/response/StartInterviewResponse.java
@@ -1,0 +1,12 @@
+package com.twopilogue.intervyou.interview.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+
+@Data
+@Builder
+public class StartInterviewResponse {
+    private long interviewId;
+    private InterviewResponse question;
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/interview/entity/Interview.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/interview/entity/Interview.java
@@ -1,0 +1,36 @@
+package com.twopilogue.intervyou.interview.entity;
+
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "interview")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Getter
+public class Interview {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 15)
+    private String job;
+
+    @Column(name = "question_count")
+    private int questionCount;
+
+    @CreationTimestamp
+    @Column(name = "create_time")
+    private LocalDateTime createTime;
+
+    @Column(name = "is_active")
+    private Boolean isActive;
+
+    @Column(name = "user_id")
+    private Long userId;
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/interview/entity/InterviewSequence.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/interview/entity/InterviewSequence.java
@@ -1,0 +1,33 @@
+package com.twopilogue.intervyou.interview.entity;
+
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "interview_sequence")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Getter
+public class InterviewSequence {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int sequence;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @CreationTimestamp
+    @Column(name = "create_time")
+    private LocalDateTime createTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interview_id", nullable = false)
+    Interview interview;
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/interview/exception/InterviewErrorResult.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/interview/exception/InterviewErrorResult.java
@@ -1,0 +1,18 @@
+package com.twopilogue.intervyou.interview.exception;
+
+import com.twopilogue.intervyou.common.BaseErrorResult;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum InterviewErrorResult implements BaseErrorResult {
+
+    ALREADY_ONGOING_INTERVIEW(HttpStatus.BAD_REQUEST, "이미 진행중인 면접이 있습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "올바른 요청값이 아닙니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/interview/exception/InterviewException.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/interview/exception/InterviewException.java
@@ -1,0 +1,10 @@
+package com.twopilogue.intervyou.interview.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class InterviewException extends RuntimeException {
+    private final InterviewErrorResult errorResult;
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/interview/repository/InterviewRepository.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/interview/repository/InterviewRepository.java
@@ -1,0 +1,10 @@
+package com.twopilogue.intervyou.interview.repository;
+
+import com.twopilogue.intervyou.interview.entity.Interview;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InterviewRepository extends JpaRepository<Interview, Long> {
+    boolean existsByUserIdAndIsActiveTrue(final long userId);
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/interview/repository/InterviewSequenceRepository.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/interview/repository/InterviewSequenceRepository.java
@@ -1,0 +1,9 @@
+package com.twopilogue.intervyou.interview.repository;
+
+import com.twopilogue.intervyou.interview.entity.InterviewSequence;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InterviewSequenceRepository extends JpaRepository<InterviewSequence, Long> {
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/interview/service/InterviewService.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/interview/service/InterviewService.java
@@ -1,0 +1,112 @@
+package com.twopilogue.intervyou.interview.service;
+
+import com.twopilogue.intervyou.interview.dto.request.StartInterviewRequest;
+import com.twopilogue.intervyou.interview.dto.chatgpt.ChatGPTRequest;
+import com.twopilogue.intervyou.interview.dto.chatgpt.Message;
+import com.twopilogue.intervyou.interview.dto.response.InterviewResponse;
+import com.twopilogue.intervyou.interview.dto.response.StartInterviewResponse;
+import com.twopilogue.intervyou.interview.dto.chatgpt.ChatGPTResponse;
+import com.twopilogue.intervyou.interview.entity.Interview;
+import com.twopilogue.intervyou.interview.entity.InterviewSequence;
+import com.twopilogue.intervyou.interview.exception.InterviewErrorResult;
+import com.twopilogue.intervyou.interview.exception.InterviewException;
+import com.twopilogue.intervyou.interview.repository.InterviewRepository;
+import com.twopilogue.intervyou.interview.repository.InterviewSequenceRepository;
+import com.twopilogue.intervyou.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class InterviewService {
+
+    @Value("${openai.model}")
+    private String model;
+
+    @Value("${openai.api.url}")
+    private String apiURL;
+
+    private final InterviewRepository interviewRepository;
+    private final InterviewSequenceRepository interviewSequenceRepository;
+    private final RestTemplate template;
+
+    private String localDateTimeToString(final LocalDateTime time) {
+        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        return time.format(formatter);
+    }
+
+    private String makePrompt(final StartInterviewRequest startInterviewRequest) {
+        final StringBuilder prompt_sb = new StringBuilder();
+        prompt_sb.append(startInterviewRequest.getJob()).append("직무에 지원했는데, 면접 시뮬레이션하자.");
+        if (startInterviewRequest.getInterviewType() == 1) {
+            prompt_sb.append("{");
+            for (String question : startInterviewRequest.getQuestionList()) {
+                prompt_sb.append(question).append(",");
+            }
+            prompt_sb.append("} 여기에서 랜덤하게 질문해줘.");
+        } else if (startInterviewRequest.getInterviewType() == 2) {
+            prompt_sb.append("면접관으로 ").append(startInterviewRequest.getQuestionType()).append(" 질문을 ").append(startInterviewRequest.getQuestionCount()).append("개").append("해줘.");
+
+        } else {
+            throw new InterviewException(InterviewErrorResult.BAD_REQUEST);
+        }
+        prompt_sb.append("네가 질문 하나를 말하면 내가 대답을 한번하는 식으로 번갈아가면서 할거고, 피드백은 면접이 끝나고 마지막에 개선점 위주로 말해주면 좋겠어. 질문할 때는 사족없이 번호랑 질문만 보내줘.");
+        return prompt_sb.toString();
+    }
+
+    private String callChatGpt(final List<Message> messages) {
+        final ChatGPTRequest request = new ChatGPTRequest(model, messages);
+        final ChatGPTResponse chatGPTResponse = template.postForObject(apiURL, request, ChatGPTResponse.class);
+        return chatGPTResponse.getChoices().get(0).getMessage().getContent();
+    }
+
+    public StartInterviewResponse startInterview(final User user, final StartInterviewRequest startInterviewRequest) {
+
+        if (interviewRepository.existsByUserIdAndIsActiveTrue(user.getId())) {
+            throw new InterviewException(InterviewErrorResult.ALREADY_ONGOING_INTERVIEW);
+        }
+
+        final Interview interview = interviewRepository.save(Interview.builder()
+                .job(startInterviewRequest.getJob())
+                .questionCount(startInterviewRequest.getQuestionCount())
+                .isActive(true)
+                .userId(user.getId())
+                .build());
+
+        final String prompt = makePrompt(startInterviewRequest);
+
+        interviewSequenceRepository.save(InterviewSequence.builder()
+                .sequence(1)
+                .content(prompt)
+                .interview(interview)
+                .build());
+
+        final List<Message> messages = new ArrayList<>();
+        messages.add(new Message("user", prompt));
+
+        final InterviewSequence interviewSequence = interviewSequenceRepository.save(InterviewSequence.builder()
+                .sequence(2)
+                .content(callChatGpt(messages))
+                .interview(interview)
+                .build());
+
+        return StartInterviewResponse.builder()
+                .interviewId(interview.getId())
+                .question(InterviewResponse.builder()
+                        .sequence(interviewSequence.getSequence())
+                        .content(interviewSequence.getContent())
+                        .createTime(localDateTimeToString(interviewSequence.getCreateTime()))
+                        .build())
+                .build();
+    }
+
+}


### PR DESCRIPTION
close #63 

1. chatGPT API와 통신하기 위해 RestTemplate을 설정했습니다.
2. `Interview`와 `InterviewSequence` 엔티티를 정의했습니다.
3. 채팅방 생성 로직을 구현했습니다.
    - 이미 진행중인 면접이 있는지 확인합니다.
    - 없다면, 프롬프트를 작성하고 면접을 시작합니다.
    - chatGPT의 첫 질문을 반환합니다.