### PR TITLE
[BE] 알림 목록 조회 API 구현

### DIFF
--- a/BE/src/main/java/com/twopilogue/intervyou/notification/constant/NotificationConstant.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/notification/constant/NotificationConstant.java
@@ -1,0 +1,9 @@
+package com.twopilogue.intervyou.notification.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class NotificationConstant {
+    public static final String READ_NOTIFICATION_LIST_SUCCESS_MESSAGE = "알림 목록 조회가 완료되었습니다.";
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/notification/controller/NotificationController.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/notification/controller/NotificationController.java
@@ -1,0 +1,26 @@
+package com.twopilogue.intervyou.notification.controller;
+
+import com.twopilogue.intervyou.common.BaseResponse;
+import com.twopilogue.intervyou.config.auth.PrincipalDetails;
+import com.twopilogue.intervyou.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import static com.twopilogue.intervyou.notification.constant.NotificationConstant.READ_NOTIFICATION_LIST_SUCCESS_MESSAGE;
+
+@CrossOrigin("*")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse> readNotificationList(@AuthenticationPrincipal final PrincipalDetails principalDetails) {
+        return new ResponseEntity<>(BaseResponse.from(READ_NOTIFICATION_LIST_SUCCESS_MESSAGE, notificationService.readNotificationList(principalDetails.getUser())), HttpStatus.OK);
+    }
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/notification/dto/response/NotificationListDtoResponse.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/notification/dto/response/NotificationListDtoResponse.java
@@ -1,0 +1,15 @@
+package com.twopilogue.intervyou.notification.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class NotificationListDtoResponse {
+    private Long notificationId;
+    private String type;
+    private String notificationContent;
+    private Long communityId;
+    private String createTime;
+    private Boolean isNewNotification;
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/notification/dto/response/NotificationListResponse.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/notification/dto/response/NotificationListResponse.java
@@ -1,0 +1,12 @@
+package com.twopilogue.intervyou.notification.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class NotificationListResponse {
+    private List<NotificationListDtoResponse> notifications;
+}

--- a/BE/src/main/java/com/twopilogue/intervyou/notification/repository/NotificationRepository.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/notification/repository/NotificationRepository.java
@@ -4,6 +4,9 @@ import com.twopilogue.intervyou.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findAllByNicknameOrderByCreateTimeDesc(final String nickname);
 }

--- a/BE/src/main/java/com/twopilogue/intervyou/notification/service/NotificationService.java
+++ b/BE/src/main/java/com/twopilogue/intervyou/notification/service/NotificationService.java
@@ -1,15 +1,21 @@
 package com.twopilogue.intervyou.notification.service;
 
 import com.twopilogue.intervyou.community.entity.Community;
+import com.twopilogue.intervyou.notification.dto.response.NotificationListDtoResponse;
+import com.twopilogue.intervyou.notification.dto.response.NotificationListResponse;
 import com.twopilogue.intervyou.notification.dto.response.NotificationResponse;
 import com.twopilogue.intervyou.notification.entity.Notification;
 import com.twopilogue.intervyou.notification.repository.NotificationRepository;
+import com.twopilogue.intervyou.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +23,11 @@ public class NotificationService {
 
     private final NotificationRepository notificationRepository;
     private final WebSocketService webSocketService;
+
+    private String localDateTimeToString(final LocalDateTime time) {
+        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        return time.format(formatter);
+    }
 
     public void sendNewNotification(final Community community, final Set<String> nicknames) {
         final String message = "[" + community.getTitle() + "]에 댓글이 달렸습니다.";
@@ -50,5 +61,21 @@ public class NotificationService {
                 e.printStackTrace();
             }
         }
+    }
+
+    public NotificationListResponse readNotificationList(final User user) {
+        final List<Notification> notifications = notificationRepository.findAllByNicknameOrderByCreateTimeDesc(user.getNickname());
+        return NotificationListResponse.builder()
+                .notifications(notifications.stream().map(
+                        notification -> NotificationListDtoResponse.builder()
+                                .notificationId(notification.getId())
+                                .type(notification.getType())
+                                .notificationContent(notification.getNotificationContent())
+                                .communityId(notification.getCommunityId())
+                                .createTime(localDateTimeToString(notification.getCreateTime()))
+                                .isNewNotification(notification.getIsNewNotification())
+                                .build()
+                ).collect(Collectors.toList()))
+                .build();
     }
 }


### PR DESCRIPTION
close #124 

1. 알림 목록 조회 API를 구현했습니다.
2. 현재는 알림을 일괄 조회하도록 구현했는데, 추후 나눠 보내는 것으로 변경될 수 있습니다.